### PR TITLE
Fixed error when tokenizer.encode returned an array of arrays

### DIFF
--- a/lib/informers/tokenizers.rb
+++ b/lib/informers/tokenizers.rb
@@ -103,7 +103,7 @@ module Informers
 
       if is_batched
         input = text_pair ? text.zip(text_pair) : text
-        encoded = @tokenizer.encode_batch(input, add_special_tokens: add_special_tokens)
+        encoded = @tokenizer.encode_batch(input, add_special_tokens: add_special_tokens).flatten
       else
         encoded = [@tokenizer.encode(text, text_pair, add_special_tokens: add_special_tokens)]
       end


### PR DESCRIPTION
Using Informers.pipeline("ner")
ner.("my sentence with entities")

threw: undefined method 'ids' for an instance of Array (NoMethodError) result = {input_ids: encoded.map(&:ids), attention_mask: encoded.map(&:attention_mask)}

Seems the encode_batch returns [[response]] but is expected to return [response] flatten() should fix this.